### PR TITLE
Fix unit test

### DIFF
--- a/tests/integration/test_long_project.py
+++ b/tests/integration/test_long_project.py
@@ -56,8 +56,9 @@ def test_repeating_export_strictly_enfores_format(long_project):
 
 
 def test_import_export_repeating_forms(long_project):
-    rep = long_project.export_repeating_instruments_events(format_type="json")
-    res = long_project.import_repeating_instruments_events(
-        to_import=rep, import_format="json"
-    )
-    assert res == 1
+    for format_type in ["xml", "json", "csv", "df"]:
+        rep = long_project.export_repeating_instruments_events(format_type=format_type)
+        res = long_project.import_repeating_instruments_events(
+            to_import=rep, import_format=format_type
+        )
+        assert res == 1

--- a/tests/unit/callback_utils.py
+++ b/tests/unit/callback_utils.py
@@ -100,7 +100,15 @@ def handle_long_project_form_event_mapping_request(**kwargs) -> MockResponse:
 def handle_long_project_repeating_form_request(**kwargs) -> MockResponse:
     """Give back list of repeating instruments for long project"""
     headers = kwargs["headers"]
-    resp = [{"form_name": "testform", "custom_form_label": ""}]
+    data = kwargs["data"]
+    resp = None
+    # import (JSON only)
+    if "data" in data:
+        repeat_forms = json.loads(data["data"][0])
+        resp = len(repeat_forms)
+    # export (JSON only)
+    else:
+        resp = [{"form_name": "testform", "custom_form_label": ""}]
 
     return (201, headers, json.dumps(resp))
 


### PR DESCRIPTION
I ended up reverting [c35bbb6](https://github.com/redcap-tools/PyCap/pull/210/commits/c35bbb633dfb91b6780552b22528619f0abcc79d). I actually like testing all the different formats in the integration test -- I ended up finding a bug that way 😄 

With these unit tests passing it brings code coverage back up to 💯 🎉

great work 👏🏻 👏🏻 👏🏻 (promise I'm not going to add anything else to this PR 😅) 